### PR TITLE
Remove spacy trf

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The filters to specify the subsets are mentioned further down.
 
 The option `--fast` uses the spacy model `en_core_web_sm` instead of `en_core_web_trf`.
 It will be faster, but less accurate.
-Some lemmas might be incorrect.
+Some lemmas might be incorrect. Warning: currently the use of `--fast` is required.
 
 The option `--name <name>` or `-n` allows to name the file the plot will be saved to.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,3 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 100
-
-[tool.pyright]
-reportMissingParameterType = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ spacy = "^3.1.0"
 llvmlite="^0.37.0"
 umap-learn = {extras = ["plot"], version = "^0.5.1"}
 en-core-web-sm = {url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.1.0/en_core_web_sm-3.1.0-py3-none-any.whl"}
-en-core-web-trf = {url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_trf-3.1.0/en_core_web_trf-3.1.0-py3-none-any.whl"}
+# en-core-web-trf = {url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_trf-3.1.0/en_core_web_trf-3.1.0-py3-none-any.whl"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
@@ -45,3 +45,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 100
+
+[tool.pyright]
+reportMissingParameterType = true


### PR DESCRIPTION
Remove the spacy transformer model "en-core-web-trf" from the pyproject.toml file to increase the speed of poetry install #patch